### PR TITLE
use /usr/local/{bin,lib} rather than /usr/{bin,lib}

### DIFF
--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -3,7 +3,7 @@
 - name: Upload vars file
   template:
     src: vars.j2
-    dest: /usr/lib/easyrsa/vars
+    dest: /usr/local/lib/easyrsa/vars
     owner: root
     group: root
     mode: 0o755

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -16,7 +16,7 @@
 - name: Install library files
   copy:
     src: /tmp/easy-rsa/easyrsa3/
-    dest: /usr/lib/easyrsa
+    dest: /usr/local/lib/easyrsa
     remote_src: true
     mode: 0o755
     owner: root
@@ -24,7 +24,7 @@
 
 - name: Set permissions
   file:
-    path: /usr/lib/easyrsa/
+    path: /usr/local/lib/easyrsa/
     state: directory
     recurse: true
     mode: o+rX
@@ -33,8 +33,8 @@
   copy:
     content: |
       #!/usr/bin/env bash
-      /usr/lib/easyrsa/easyrsa --vars=/usr/lib/easyrsa/vars "$@"
-    dest: /usr/bin/easyrsa
+      /usr/local/lib/easyrsa/easyrsa --vars=/usr/local/lib/easyrsa/vars "$@"
+    dest: /usr/local/bin/easyrsa
     mode: 0o755
     owner: root
     group: root

--- a/templates/vars.j2
+++ b/templates/vars.j2
@@ -49,7 +49,7 @@ fi
 # itself, which is also where the configuration files are located in the
 # easy-rsa tree.
 
-set_var EASYRSA /usr/lib/easyrsa
+set_var EASYRSA /usr/local/lib/easyrsa
 
 # If your OpenSSL command is not in the system PATH, you will need to define the
 # path to it here. Normally this means a full path to the executable, otherwise


### PR DESCRIPTION
I suggest moving the installation of easyrsa to /usr/local. That's the more proper place for self-installed stuff, not delivered in packaged.