### PR TITLE
Allow specifying handler after CRL update

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -79,7 +79,7 @@ easyrsa_revoked: []
 easyrsa_download: "{{ easyrsa_clients }}"
 # A list of specific certificates (and keys) to download.
 
-easyrsa_crl_handler: []
+easyrsa_crl_handlers: []
 # A list of handlers to run after a new CRL has been generated.
 
 easyrsa_download_pki: false

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -79,6 +79,9 @@ easyrsa_revoked: []
 easyrsa_download: "{{ easyrsa_clients }}"
 # A list of specific certificates (and keys) to download.
 
+easyrsa_crl_handler: []
+# A list of handlers to run after a new CRL has been generated.
+
 easyrsa_download_pki: false
 # Set to true to download the whole pki folder as a zip folder to the Ansible
 # controller. Perhaps you want to set `easyrsa_download` to an empty list to not

--- a/tasks/revoke.yml
+++ b/tasks/revoke.yml
@@ -13,3 +13,4 @@
 - name: Generate CRL
   command: easyrsa gen-crl
   when: _result is changed
+  notify: "{{ easyrsa_crl_handler }}"

--- a/tasks/revoke.yml
+++ b/tasks/revoke.yml
@@ -13,4 +13,4 @@
 - name: Generate CRL
   command: easyrsa gen-crl
   when: _result is changed
-  notify: "{{ easyrsa_crl_handler }}"
+  notify: "{{ easyrsa_crl_handlers }}"


### PR DESCRIPTION
Useful for e.g. restarting OpenVPN running in unprivileged mode.