### PR TITLE
Fix id call to be compatible with macos

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -40,8 +40,8 @@ easyrsa_crl_handlers: []
 easyrsa_download_pki: false
 easyrsa_download_pki_extract: true
 easyrsa_download_dir: '/tmp/'
-easyrsa_download_user: "{{ lookup('pipe', 'id --user --name') }}"
-easyrsa_download_group: "{{ lookup('pipe', 'id --group --name') }}"
+easyrsa_download_user: "{{ lookup('pipe', 'id -un') }}"
+easyrsa_download_group: "{{ lookup('pipe', 'id -gn') }}"
 easyrsa_to_pkcs12: []
 easyrsa_to_pkcs8: []
 easyrsa_to_pkcs7: []

--- a/meta/argument_specs.yml
+++ b/meta/argument_specs.yml
@@ -224,12 +224,12 @@ argument_specs:
 
       easyrsa_download_user:
         type: str
-        default: "{{ lookup('pipe', 'id --user --name') }}"
+        default: "{{ lookup('pipe', 'id -un') }}"
         description: 'The user that will own the downloaded certs/keys.'
 
       easyrsa_download_group:
         type: str
-        default: "{{ lookup('pipe', 'id --group --name') }}"
+        default: "{{ lookup('pipe', 'id -gn') }}"
         description: 'The group that will own the downloaded certs/keys.'
       # }}}
       # Conversions {{{

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -324,7 +324,7 @@
                   id: {{ id }}
               vars:
                 owner: "{{ lookup('pipe', 'stat -c \"%u\" ' + _easyrsa__path) }}"
-                id: "{{ lookup('pipe', 'id --user ' + easyrsa_download_user) }}"
+                id: "{{ lookup('pipe', 'id -u ' + easyrsa_download_user) }}"
               loop:
                 - "{{ [easyrsa_download_dir_alt2, easyrsa_pki_dir | basename] | path_join }}"
                 - "{{ [easyrsa_download_dir_alt2, easyrsa_pki_dir | basename, 'issued']
@@ -341,7 +341,7 @@
                   gid: {{ gid }}
               vars:
                 group: "{{ lookup('pipe', 'stat -c \"%g\" ' + _easyrsa__path) }}"
-                gid: "{{ lookup('pipe', 'id --group ' + easyrsa_download_user) }}"
+                gid: "{{ lookup('pipe', 'id -g ' + easyrsa_download_user) }}"
               loop:
                 - "{{ [easyrsa_download_dir_alt2, easyrsa_pki_dir | basename] | path_join }}"
                 - "{{ [easyrsa_download_dir_alt2, easyrsa_pki_dir | basename, 'issued']


### PR DESCRIPTION
Current pipe call is not compatible with MacOS, because no `--user` or `--group` flags are available.
With short flags it works on linux and MacOS